### PR TITLE
Add menu overlay support

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,21 @@
             background-color: #444; /* Darker background on hover */
         }
 
+        /* Overlay for mobile menu */
+        .menu-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent background */
+            z-index: 9998; /* Just under the menu */
+            display: none; /* Hidden by default */
+        }
+        .menu-overlay.active {
+            display: block;
+        }
+
 
         /* Scroll to top button styles */
         #scrollToTopBtn {
@@ -580,6 +595,7 @@
         mobileMenuButton.addEventListener('click', () => {
             mobileMenu.classList.toggle('active');
             body.classList.toggle('menu-open'); // Toggle 'menu-open' class on body
+            menuOverlay.classList.toggle('active'); // Show or hide overlay
         });
 
         // Close mobile menu when a link is clicked or overlay is clicked
@@ -587,6 +603,7 @@
             link.addEventListener('click', () => {
                 mobileMenu.classList.remove('active');
                 body.classList.remove('menu-open');
+                menuOverlay.classList.remove('active');
             });
         });
 
@@ -594,6 +611,7 @@
         menuOverlay.addEventListener('click', () => {
             mobileMenu.classList.remove('active');
             body.classList.remove('menu-open');
+            menuOverlay.classList.remove('active');
         });
 
 


### PR DESCRIPTION
## Summary
- add CSS for a semi-transparent `.menu-overlay`
- toggle overlay visibility when mobile menu opens or closes
- close menu and overlay when clicking the overlay or a menu link

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684046b7ad1483338393daa5c16f6de5