### PR TITLE
Remove API key from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# JRKCoin
+
+This project includes a static `index.html` page with JavaScript that calls the Gemini API. For security reasons, the API key is not stored in the repository. Instead, the code contains a placeholder value:
+
+```javascript
+const apiKey = "YOUR_API_KEY_HERE";
+```
+
+To run the site, supply your Gemini API key at runtime. A simple approach is to keep your key in a separate JavaScript file that is ignored by Git (for example, `config.js`) and load it before `index.html`'s script:
+
+1. Create a file called `config.js` next to `index.html` and define your key:
+
+```javascript
+// config.js
+const apiKey = "<your real API key>";
+```
+
+2. Add `config.js` to `.gitignore` so the key is never committed.
+3. Include `config.js` in the page **before** the main script so that the variable is defined at runtime.
+
+Alternatively, you can serve the key from a backend endpoint that reads the value from an environment variable and returns it to authenticated users. This keeps the key out of client-side code entirely.
+
+Never commit your actual API key to the repository.

--- a/Site
+++ b/Site
@@ -543,7 +543,7 @@
                 chatHistory.push({ role: "user", parts: [{ text: prompt }] });
                 const payload = { contents: chatHistory };
                 // API key is now provided by the user
-                const apiKey = "AIzaSyBSIinR7LBQsVj4DK8tjeZ9Syw5XwFa9XM";
+                const apiKey = "YOUR_API_KEY_HERE";
                 const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
 
                 const response = await fetch(apiUrl, {

--- a/index.html
+++ b/index.html
@@ -543,7 +543,7 @@
                 chatHistory.push({ role: "user", parts: [{ text: prompt }] });
                 const payload = { contents: chatHistory };
                 // API key is now provided by the user
-                const apiKey = "AIzaSyBSIinR7LBQsVj4DK8tjeZ9Syw5XwFa9XM";
+                const apiKey = "YOUR_API_KEY_HERE";
                 const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
 
                 const response = await fetch(apiUrl, {


### PR DESCRIPTION
## Summary
- remove the hardcoded Gemini API key and use a placeholder
- document how to provide the key at runtime in `README.md`
- ignore a `config.js` file for local API key storage

## Testing
- `grep -R "AIzaSyBSIinR7LBQsVj4DK8tjeZ9Syw5XwFa9XM" -n || echo 'no occurrences'`

------
https://chatgpt.com/codex/tasks/task_b_684044b45c8883339591ace8911b45ec