### PR TITLE
Fix mobile overlay

### DIFF
--- a/Site
+++ b/Site
@@ -72,6 +72,18 @@
             background-color: #444; /* Darker background on hover */
         }
 
+        /* Overlay for mobile menu */
+        .menu-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background-color: rgba(0,0,0,0.5);
+            z-index: 9998;
+        }
+        body.menu-open .menu-overlay {
+            display: block;
+        }
+
 
         /* Scroll to top button styles */
         #scrollToTopBtn {

--- a/index.html
+++ b/index.html
@@ -72,6 +72,18 @@
             background-color: #444; /* Darker background on hover */
         }
 
+        /* Overlay for mobile menu */
+        .menu-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background-color: rgba(0,0,0,0.5);
+            z-index: 9998;
+        }
+        body.menu-open .menu-overlay {
+            display: block;
+        }
+
 
         /* Scroll to top button styles */
         #scrollToTopBtn {


### PR DESCRIPTION
## Summary
- show a dark overlay when the mobile menu is open

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684043836b808333ba666c7463996dde